### PR TITLE
Move pipeline to use DevCentral

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     - repository: niveristand-custom-device-build-tools
       type:       github
       ref:        main
-      endpoint:   ni (2)
+      endpoint:   nivs-custom-devices
       name:       ni/niveristand-custom-device-build-tools
 
 stages:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update pipeline to use DevCentral instead of Users project.

### Why should this Pull Request be merged?

This is necessary to move the builds to DevCentral.

### What testing has been done?

Will run the pipeline as part of this PR.