### PR TITLE
Bump version to 25.0.0, drop 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library defines a class-based producer-consumer messaging system that can be used to communicate between a single producer custom device engine and an arbitrary number of consumer custom device engines.
 
 ## LabVIEW Version
-LabVIEW 2020
+LabVIEW 2023
 
 ## Dependencies
 Requires the [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools) to run automated tests. Install the latest package from the [release page](https://github.com/ni/niveristand-custom-device-testing-tools/releases)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,6 @@ stages:
           bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
-        - version: '2025'
-          bitness: '64bit'
 
       buildSteps:
         - projectLocation: 'Source\Message Library.lvproj'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,12 +16,12 @@ resources:
 stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
-      lvVersionsToBuild: 
-        - version: '2021'
-          bitness: '64bit'
+      lvVersionsToBuild:
         - version: '2023'
           bitness: '64bit'
         - version: '2024'
+          bitness: '64bit'
+        - version: '2025'
           bitness: '64bit'
 
       buildSteps:
@@ -30,7 +30,7 @@ stages:
           target: 'All'
           buildSpec: 'All'
 
-      releaseVersion: '24.0.0'
+      releaseVersion: '25.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\messaging_library'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version to 25.0.0 and drop the automated build for VeriStand 2021

### Why should this Pull Request be merged?

Necessary for a future release.

### What testing has been done?

NA
