### PR TITLE
Dev/25.0.0 fix. Revert the proj setting change and build message lib

### DIFF
--- a/Source/Message Library.lvproj
+++ b/Source/Message Library.lvproj
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
-<Project Type="Project" LVVersion="21008000">
+<Project Type="Project" LVVersion="20008000">
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Item Name="My Computer" Type="My Computer">
 		<Property Name="NI.SortType" Type="Int">3</Property>
@@ -364,7 +364,7 @@
 				<Property Name="Bld_modifyLibraryFile" Type="Bool">true</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{8736D784-2CB2-4D3A-92AF-8031C6E8C40C}</Property>
-				<Property Name="Bld_version.build" Type="Int">8</Property>
+				<Property Name="Bld_version.build" Type="Int">7</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">CDMessaging.lvlibp</Property>
 				<Property Name="Destination[0].path" Type="Path">../Built/Windows/CDMessaging.lvlibp</Property>
@@ -374,7 +374,7 @@
 				<Property Name="Destination[1].path" Type="Path">../Built/Windows</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="PackedLib_callersAdapt" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{C725A242-202C-4C23-A0D7-89FEB97E17FF}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{B6BA6EEB-213B-4C51-BFC2-0CD4F5C63576}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Messaging.lvlib</Property>
@@ -385,7 +385,6 @@
 				<Property Name="Source[1].sourceInclusion" Type="Str">TopLevel</Property>
 				<Property Name="Source[1].type" Type="Str">Library</Property>
 				<Property Name="SourceCount" Type="Int">2</Property>
-				<Property Name="TgtF_enableDebugging" Type="Bool">true</Property>
 				<Property Name="TgtF_fileDescription" Type="Str">Messaging</Property>
 				<Property Name="TgtF_internalName" Type="Str">Messaging</Property>
 				<Property Name="TgtF_legalCopyright" Type="Str">Copyright © 2019 </Property>
@@ -510,7 +509,7 @@
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{BC170595-AA66-4507-883C-41ED45DC8FD2}</Property>
 				<Property Name="Bld_targetDestDir" Type="Path">/Linux_x64</Property>
-				<Property Name="Bld_version.build" Type="Int">5</Property>
+				<Property Name="Bld_version.build" Type="Int">4</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">CDMessaging.lvlibp</Property>
 				<Property Name="Destination[0].path" Type="Path">/Linux_x64/CDMessaging.lvlibp</Property>
@@ -521,7 +520,7 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{0ED28F88-C1B4-427D-87E8-430893399010}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{9106121A-8A24-4578-AC09-15DFD3AA204D}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux x64/Messaging.lvlib</Property>
@@ -532,7 +531,6 @@
 				<Property Name="Source[1].sourceInclusion" Type="Str">TopLevel</Property>
 				<Property Name="Source[1].type" Type="Str">Library</Property>
 				<Property Name="SourceCount" Type="Int">2</Property>
-				<Property Name="TgtF_enableDebugging" Type="Bool">true</Property>
 				<Property Name="TgtF_fileDescription" Type="Str">Messaging</Property>
 				<Property Name="TgtF_internalName" Type="Str">Messaging</Property>
 				<Property Name="TgtF_legalCopyright" Type="Str">Copyright © 2019 </Property>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,6 @@ stages:
           bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
-        - version: '2025'
-          bitness: '64bit'
 
       buildSteps:
         - projectLocation: 'Source\Message Library.lvproj'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,8 @@ stages:
           bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
+        - version: '2025'
+          bitness: '64bit'
 
       buildSteps:
         - projectLocation: 'Source\Message Library.lvproj'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Revert the proj setting changes and make sure the tool builds on all supported LV 

### Why should this Pull Request be merged?

Required for future release

### What testing has been done?
PR build
