### PR TITLE
Drop lv 23 and Add lv 26 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library defines a class-based producer-consumer messaging system that can be used to communicate between a single producer custom device engine and an arbitrary number of consumer custom device engines.
 
 ## LabVIEW Version
-LabVIEW 2023
+LabVIEW 2026
 
 ## Dependencies
 Requires the [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools) to run automated tests. Install the latest package from the [release page](https://github.com/ni/niveristand-custom-device-testing-tools/releases)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library defines a class-based producer-consumer messaging system that can be used to communicate between a single producer custom device engine and an arbitrary number of consumer custom device engines.
 
 ## LabVIEW Version
-LabVIEW 2026
+LabVIEW 2024
 
 ## Dependencies
 Requires the [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools) to run automated tests. Install the latest package from the [release page](https://github.com/ni/niveristand-custom-device-testing-tools/releases)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,12 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2023'
-          bitness: '64bit'
+        
         - version: '2024'
           bitness: '64bit'
         - version: '2025'
+          bitness: '64bit'
+        - version: '2026'
           bitness: '64bit'
 
       buildSteps:
@@ -30,7 +31,7 @@ stages:
           target: 'All'
           buildSpec: 'All'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '26.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\messaging_library'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Drop LV2023 build.
Add LV2026 to build using lv2026.

### Why should this Pull Request be merged?

Required for future release

### What testing has been done?

PR build
