### PR TITLE
Update azure-pipelines.yml to bump to 26.5.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
           target: 'All'
           buildSpec: 'All'
 
-      releaseVersion: '26.0.0'
+      releaseVersion: '26.5.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\messaging_library'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ stages:
         target: 'My Computer'
         buildSpec: 'Messaging'
 
-      releaseVersion: '26.0.0'
+      releaseVersion: '26.5.0'
       branch: 'main'
       debugBuild: 'no'
       repoName: 'niveristand-custom-device-message-library'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Bump the version to 26.5.0

### Why should this Pull Request be merged?
Necessary for 26.5 release

### What testing has been done?
None